### PR TITLE
Switch from `jsonnet fmt` to `jsonnetfmt`

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -46,6 +46,12 @@
   :type '(string)
   :group 'jsonnet)
 
+(defcustom jsonnet-fmt-command
+  "jsonnetfmt"
+  "Jsonnet format command."
+  :type '(string)
+  :group 'jsonnet)
+
 (defcustom jsonnet-library-search-directories
   nil
   "Sequence of Jsonnet library search directories, with later entries shadowing earlier entries."
@@ -322,7 +328,7 @@ If not provided, current point is used."
 (defun jsonnet-reformat-buffer ()
   "Reformat entire buffer using the Jsonnet format utility."
   (interactive)
-  (call-process-region (point-min) (point-max) jsonnet-command t t nil "fmt" "-"))
+  (call-process-region (point-min) (point-max) jsonnet-fmt-command t t nil "-"))
 
 (define-key jsonnet-mode-map (kbd "C-c C-r") 'jsonnet-reformat-buffer)
 


### PR DESCRIPTION
## Description

With jsonnet v0.13.0, `jsonnet fmt` is now its own executable called
`jsonnetfmt`. According to the release notes:

> jsonnet fmt is now its own executable called jsonnetfmt. This helps if you're
> using the Go version but you still want to have a formatter in your $PATH.
> Soon we want to have jsonnetfmt be a binary in the Go version too. If you've
> got scripts that run jsonnet fmt, you will need to delete the space from them.

https://github.com/google/jsonnet/releases/tag/v0.13.0

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I have tested this locally using jsonnet v0.14.0.

```
$ jsonnet --version
Jsonnet commandline interpreter v0.14.0
$ jsonnetfmt --version
Jsonnet reformatter v0.14.0
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.