### PR TITLE
Autoload .libsonnet addition to auto-mode-alist

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -294,6 +294,7 @@ If not inside of a multiline string, return nil."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist (cons "\\.jsonnet\\'" 'jsonnet-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist (cons "\\.libsonnet\\'" 'jsonnet-mode))
 
 ;; Utilities for evaluating and jumping around Jsonnet code.


### PR DESCRIPTION

## Description
The addition of .jsonnet to auto-load-alist is autoloaded, but not .libsonnet,
so jsonnet-mode will not be activated if a .libsonnet file is visited before any
.jsonnet file. This looks like an oversight.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
