### PR TITLE
preserve point when adjusting indent

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -576,9 +576,10 @@ TYPE is an opening paren-like character."
   (interactive)
   (let ((calculated-indent (jsonnet-calculate-indent)))
     (when (not (eq calculated-indent (current-indentation)))
-      (beginning-of-line)
-      (delete-char (current-indentation))
-      (indent-to calculated-indent))))
+      (save-excursion
+        (beginning-of-line)
+        (delete-char (current-indentation))
+        (indent-to calculated-indent)))))
 
 ;;;###autoload
 (define-derived-mode jsonnet-mode prog-mode "Jsonnet"


### PR DESCRIPTION
## Description
This updates `jsonnet-indent-line` to preserve point when it
changes indentation.  Previously it'd leave point at the beginning of
text of the line.

## Motivation and Context
Fixes a bug when reindenting with, eg, `<tab>`.

## How Has This Been Tested?
I use this change myself, and it does what it should.  Also, pretty obviously correct.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
