### PR TITLE
Align close paren with opening paren

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -610,6 +610,7 @@ TYPE is an opening paren-like character."
         (setq-local smie-indent-functions '(jsonnet-smie--indent-inside-multiline-string
                                             smie-indent-fixindent
                                             smie-indent-bob
+                                            smie-indent-close
                                             smie-indent-comment
                                             smie-indent-comment-continue
                                             smie-indent-comment-close


### PR DESCRIPTION
## Description
This fixes smie indentation by aligning close paren with opening paren.

## Motivation and Context
The close paren should be aligned with its opening one. eg:
```
  foo: [
    "bar"
  ]
```
However, current indentation behavior would make it
```
  foo: [
    "bar"
    ]
```