### PR TITLE
Pass the local buffer cmd and args to subprocess

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -651,26 +651,27 @@ TYPE is an opening paren-like character."
     (when-let ((output-window (get-buffer-window output-buffer-name t)))
       (quit-window nil output-window)
       (redisplay))
-    (with-current-buffer (get-buffer-create output-buffer-name)
-      (setq buffer-read-only nil)
-      (erase-buffer)
-      (let ((args (nconc jsonnet-command-options
-                         (cl-loop for dir in search-dirs
-                                  collect "-J"
-                                  collect dir)
-                         (list file-to-eval))))
-        (if (zerop (apply #'call-process jsonnet-command nil t nil args))
+    (let ((cmd jsonnet-command)
+          (args (append jsonnet-command-options
+                        (cl-loop for dir in search-dirs
+                                collect "-J"
+                                collect dir)
+                       (list file-to-eval))))
+      (with-current-buffer (get-buffer-create output-buffer-name)
+        (setq buffer-read-only nil)
+        (erase-buffer)
+        (if (zerop (apply #'call-process cmd nil t nil args))
             (progn
               (when (fboundp 'json-mode)
                 (json-mode))
               (view-mode))
-          (compilation-mode nil)))
-      (goto-char (point-min))
-      (display-buffer (current-buffer)
-                      '((display-buffer-pop-up-window
-                         display-buffer-reuse-window
-                         display-buffer-at-bottom
-                         display-buffer-pop-up-frame))))))
+          (compilation-mode nil))
+        (goto-char (point-min))
+        (display-buffer (current-buffer)
+                        '((display-buffer-pop-up-window
+                           display-buffer-reuse-window
+                           display-buffer-at-bottom
+                           display-buffer-pop-up-frame)))))))
 
 (define-key jsonnet-mode-map (kbd "C-c C-c") 'jsonnet-eval-buffer)
 


### PR DESCRIPTION
Any file local or dir local variables should be passed from the
current jsonnet buffer to the subprocess we are executing.  Since they
will all be buffer local, we can do this by moving the let capturing
the command and args to outside the `with-current-buffer` that is
operating on the output buffer `*jsonnet-output*`.

This allows us to evaluate a buffer like this,
```
{
  hello: std.extVar('foo'),
}

// Local Variables:
// eval: (setq-local jsonnet-command-options '("--ext-str" "foo=world"))
// End:
```

## Motivation and Context

This allows defining a `.dir-local.el` file in a directory that sets custom command arguments or changes the jsonnet executable.  We would want to do this because it's really common to see wrappers for jsonnet, and being able to set the command on a per directory basis is more flexible then setting it globally.  Same applies to file local above, but it's just easier to write a demo with a file local variable.

## How Has This Been Tested?
If the above example evaluates without error, then it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
