### PR TITLE
Add code coverage via Coveralls and Undercover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel: true
   finish:
     needs: test
     runs-on: ubuntu-latest
@@ -51,3 +52,4 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,15 @@ jobs:
       run: cask build
     - name: Run tests
       run: cask exec buttercup -L .
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Byte compile
       run: cask build
     - name: Run tests
-      run: cask exec buttercup -L .
+      run: UNDERCOVER_FORCE=true cask exec buttercup -L .
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{matrix.emacs_version == 'snapshot'}}
+    continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
     strategy:
       matrix:
         emacs_version:
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Emacs
       uses: purcell/setup-emacs@master
       with:
-        version: ${{matrix.emacs_version}}
+        version: ${{ matrix.emacs_version }}
     - name: Set up Jsonnet
       uses: zendesk/setup-jsonnet@v7
     - name: Set up Cask
@@ -43,6 +43,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: emacs-${{ matrix.emacs_version }}
         parallel: true
   finish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: cask install
+    - name: Run tests before byte compilation
+      run: UNDERCOVER_FORCE=true cask exec buttercup -L .
     - name: Byte compile
       run: cask build
-    - name: Run tests
-      run: UNDERCOVER_FORCE=true cask exec buttercup -L .
+    - name: Run tests after byte compilation
+      run: cask exec buttercup -L .
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/Cask
+++ b/Cask
@@ -8,6 +8,5 @@
 
 (development
  (depends-on "buttercup")
- ;; Remove undercover for now.
- ;; (depends-on "undercover")
+ (depends-on "undercover")
  (depends-on "f"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![CI](https://github.com/tminor/jsonnet-mode/workflows/CI/badge.svg)](https://github.com/tminor/jsonnet-mode/actions?query=workflow%3A%22CI%22+branch%3Amain)
-[![Coverage Status](https://coveralls.io/repos/github/tminor/jsonnet-mode/badge.svg?branch=ci-test)](https://coveralls.io/github/tminor/jsonnet-mode?branch=ci-test)
+[![Coverage Status](https://coveralls.io/repos/github/tminor/jsonnet-mode/badge.svg?branch=code-coverage)](https://coveralls.io/github/tminor/jsonnet-mode?branch=code-coverage)
 
 # jsonnet-mode
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![CI](https://github.com/tminor/jsonnet-mode/workflows/CI/badge.svg)](https://github.com/tminor/jsonnet-mode/actions?query=workflow%3A%22CI%22+branch%3Amain)
-[![Coverage Status](https://coveralls.io/repos/github/tminor/jsonnet-mode/badge.svg?branch=code-coverage)](https://coveralls.io/github/tminor/jsonnet-mode?branch=code-coverage)
+[![Coverage Status](https://coveralls.io/repos/github/tminor/jsonnet-mode/badge.svg?branch=main)](https://coveralls.io/github/tminor/jsonnet-mode?branch=main)
 
 # jsonnet-mode
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![CI](https://github.com/tminor/jsonnet-mode/workflows/CI/badge.svg)](https://github.com/tminor/jsonnet-mode/actions?query=workflow%3A%22CI%22+branch%3Amain)
+[![Coverage Status](https://coveralls.io/repos/github/tminor/jsonnet-mode/badge.svg?branch=ci-test)](https://coveralls.io/github/tminor/jsonnet-mode?branch=ci-test)
 
 # jsonnet-mode
 

--- a/tests/jsonnet-mode-test.el
+++ b/tests/jsonnet-mode-test.el
@@ -3,9 +3,8 @@
 (when (require 'undercover nil t)
   (let ((undercover-force-coverage t))
     (undercover "*.el" "tests/*.el"
-                (:report-file "./coverage-final.json")
                 (:send-report nil)
-                (:report-format 'coveralls))))
+                (:report-format 'lcov))))
 
 (require 'jsonnet-mode)
 (require 'undercover)

--- a/tests/jsonnet-mode-test.el
+++ b/tests/jsonnet-mode-test.el
@@ -1,9 +1,14 @@
 ;;; jsonnet-mode-test.el --- Jsonnet Mode Tests -*- lexical-binding: t -*-
 
-;; (when (require 'undercover nil t)
-;;   (undercover "*.el"))
+(when (require 'undercover nil t)
+  (let ((undercover-force-coverage t))
+    (undercover "*.el" "tests/*.el"
+                (:report-file "./coverage-final.json")
+                (:send-report nil)
+                (:report-format 'coveralls))))
 
 (require 'jsonnet-mode)
+(require 'undercover)
 
 (progn (require 'f)
        (add-to-list 'load-path (f-parent (f-parent (f-this-file))))

--- a/tests/jsonnet-mode-test.el
+++ b/tests/jsonnet-mode-test.el
@@ -2,7 +2,7 @@
 
 (when (require 'undercover nil t)
   (let ((undercover-force-coverage t))
-    (undercover "*.el" "tests/*.el"
+    (undercover "jsonnet-mode.el"
                 (:send-report nil)
                 (:report-format 'lcov))))
 

--- a/tests/jsonnet-mode-test.el
+++ b/tests/jsonnet-mode-test.el
@@ -4,7 +4,8 @@
   (let ((undercover-force-coverage t))
     (undercover "jsonnet-mode.el"
                 (:send-report nil)
-                (:report-format 'lcov))))
+                (:report-format 'lcov)
+                (:merge-report nil))))
 
 (require 'jsonnet-mode)
 (require 'undercover)

--- a/tests/jsonnet-mode-test.el
+++ b/tests/jsonnet-mode-test.el
@@ -2,7 +2,7 @@
 
 (when (require 'undercover nil t)
   (let ((undercover-force-coverage t))
-    (undercover "jsonnet-mode.el"
+    (undercover "jsonnet-mode.el" "tests/*.el"
                 (:send-report nil)
                 (:report-format 'lcov)
                 (:merge-report nil))))


### PR DESCRIPTION
This adds:
- GitHub Workflow configuration for Coveralls;
- Undercover as a development dependency; and
- Some initialization code for Undercover in test file.
