### PR TITLE
Display the eval buffer using the default display-buffer-alist

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ There are several customizable parameters that you may configure in this mode:
 - `jsonnet-use-smie` enables SMIE-provided indentation.
 - `jsonnet-indent-level` changes the number of spaces used to indent
   Jsonnet code.
+
+## Buffer display
+
+The potential buffers that the mode creates are:
+
+* `*jsonnet output*`
+
+If you require special customization of their display, you can either
+use `display-buffer-alist` as described [above](#buffer-display) or
+investigate the options provided in your distribution of GNU Emacs.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ in most cases.
 any errors are encountered, they should be conveniently displayed in
 `compilation-mode`.
 
+It will create a buffer called `*jsonnet output*`. Default display
+behaviour of these buffers can be customized using
+`display-buffer-alist` (see [The Zen of Buffer
+Display](https://www.gnu.org/software/emacs/manual/html_node/elisp/The-Zen-of-Buffer-Display.html)
+for examples of how to do this).
+
 ## Navigation
 
 `jsonnet-mode` also provides some methods to make navigation easier. In

--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -648,15 +648,12 @@ TYPE is an opening paren-like character."
                          (lambda ()
                            (member (file-name-directory (file-truename (buffer-file-name)))
                                    directories))))
-    (when-let ((output-window (get-buffer-window output-buffer-name t)))
-      (quit-window nil output-window)
-      (redisplay))
     (let ((cmd jsonnet-command)
           (args (append jsonnet-command-options
                         (cl-loop for dir in search-dirs
-                                collect "-J"
-                                collect dir)
-                       (list file-to-eval))))
+                                 collect "-J"
+                                 collect dir)
+                        (list file-to-eval))))
       (with-current-buffer (get-buffer-create output-buffer-name)
         (setq buffer-read-only nil)
         (erase-buffer)
@@ -667,11 +664,7 @@ TYPE is an opening paren-like character."
               (view-mode))
           (compilation-mode nil))
         (goto-char (point-min))
-        (display-buffer (current-buffer)
-                        '((display-buffer-pop-up-window
-                           display-buffer-reuse-window
-                           display-buffer-at-bottom
-                           display-buffer-pop-up-frame)))))))
+        (display-buffer (current-buffer) '(nil (inhibit-same-window . t)))))))
 
 (define-key jsonnet-mode-map (kbd "C-c C-c") 'jsonnet-eval-buffer)
 


### PR DESCRIPTION
There is so rather complex implicit behavior when using jsonnet-eval-buffer, it was really really crazy before #27 when @tminor picked up bad scoping in `with-current-buffer`.  I actually don't know how anyone used it before #27, it was essentially burying the buffer on execute, which was the confusing behavior i was seeing, turned out one machine was running the melpa version on was running my fork.  Anyway, I was really trying to make small changes, because i don't like it when people go to edit one sexp and then end up re-writing the entire function, so this PR is only covering how buffer display works,

So to recap, the current implementation works as follows
1. delete 1 window containing *jsonnet-output*
2. run jsonnet command and populate buffer
3. display-buffer using a default set of rules
> 1. display-buffer-pop-up-window (this will almost always succeed)
> 2. display-buffer-reuse-window (this will never succeed, we deleted the window in step 1, unless you have multiple windows all with the *jsonnet-output* buffer then it will be reused)
> 3. display-buffer-at-bottom (starts splitting and displaying the buffer in new windows)
> 4. display-buffer-pop-up-frame (creates a new frame to display the buffer)

Ok, so i really don't like this behavior, mostly because it begins with deleting my existing window, this leads to either window flapping where i happens to have the buffer in an already created side-window, or worse, window thrashing, where the display is rearranging as windows are deleted and then new ones appear miraculously. I don't think it ever made it to 3 or 4.

I have very minimal customization of my window display configuration, but even with no `display-buffer-alist` the behavior here feels unpredictable.  It's trying to force the window from where ever it is into a side window at the bottom of the screen, and it's not straight forward to prevent it, because once the window is deleted, it's not obvious how to return it to it's original location.  and even if i did it would still be flapping about windows disappearing only to reappear in the same place


So what i propose here is minimalism, the flow works like this
1. run jsonnet command and populate buffer
2. call display-buffer with no arguments other than `'(inhibt-same-window . t)` this will inhibit the default same window behavior that can sometimes occur.

This is the simplest way i can imagine it working, i press C-c C-c and then the buffer evaluates and is displayed somewhere, not over the top of the current window.  If the output window is already visible, then it's reused.

If users want to customize the behavior and delete the window every time they execute the function, the could advise it, and if they want to change the display to use a side-window, then they can customize the alist like so

```
(customize-set-variable
 'display-buffer-alist
 '(("\\*jsonnet out\\*"
    (display-buffer-pop-up-window display-buffer-reuse-window display-buffer-at-bottom display-buffer-pop-up-frame))))
```

WDYT?  I realise this is very different to what is there, but it's more inline with other compile buffer behavior and it's aiming to not be opinionated.  Something simple that people can build on

Sorry for the long post, got a bit carried away

## Have you written tests for your change?
<!--- If applicable, include unit tests for your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
