### PR TITLE
Prevent highlighting portions of variables that match built-in syntax.

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -101,8 +101,8 @@ For example:
           "\\(([a-zA-Z0-9_, ]*)\s*=\\|\s*=\s*function\\)"))
 
 (defconst jsonnet-font-lock-keywords-1
-  (let ((builtin-regex (regexp-opt '("assert" "else" "error" "for" "function" "if" "import" "importstr" "in" "local" "self" "super" "then") 'words))
-        (constant-regex (regexp-opt '("false" "null" "true") 'words))
+  (let ((builtin-regex (regexp-opt '("assert" "else" "error" "for" "function" "if" "import" "importstr" "in" "local" "self" "super" "then") 'symbols))
+        (constant-regex (regexp-opt '("false" "null" "true") 'symbols))
         (function-name-regex jsonnet--function-name-regexp)
         ;; Any other local bindings are variables
         (variable-name-regex (concat "local \\(" jsonnet--identifier-regexp "\\)\s+="))


### PR DESCRIPTION
In the following Jsonnet snippet, the `skip_if` parameter contains an underscore, which is recognized as a word boundary in `jsonnet-mode`.  In this case, the `if` component of the parameter is highlighted whereas the `skip_` substring is not.

```
local gather_from(arr, field, skip_if="") =
  std.foldl(function(res, config) append(res, config[field], skip_if), arr, {});

{
  sources_from(arr): gather_from(arr, "sources", skip_if="source_channel"),
  publishers_from(arr): gather_from(arr, "publishers"),
  transforms_from(arr): gather_from(arr, "transforms"),
}
```

This PR adjusts the regular expressions according to the definition of a "symbol" instead of a "word", as defined [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Functions.html).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
